### PR TITLE
ESYNC_8991 - avoid new connections for DDL operations

### DIFF
--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/kernel/NativeJDBCSeq.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/kernel/NativeJDBCSeq.java
@@ -320,9 +320,12 @@ public class NativeJDBCSeq
                     // as to not potentially insert records ahead of what the database thinks is the next sequence
                     // value.
 
+                    // Deprecated
                     // first we have to allocate a new connection as some databases do an implicit commit
                     // if a DDL gets changed. Others do blow up on a DDL change
-                    try (Connection newConn = getConnection(store, true)) {
+
+                    // ask DBDictionary if a new connection is needed
+                    try (Connection newConn = getConnection(store, dict.needNewDDLConn)) {
 
                         if (!dict.isSequenceIncrementCorrect(newConn, _seq)) {
 

--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/DBDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/DBDictionary.java
@@ -275,6 +275,7 @@ public class DBDictionary
     public boolean supportsSimpleCaseExpression = true;
     public boolean supportsGeneralCaseExpression = true;
     public boolean useWildCardForCount = false;
+    public boolean needNewDDLConn = true;
 
     /**
      * Some Databases append whitespace after the schema name

--- a/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/PostgresDictionary.java
+++ b/openjpa-jdbc/src/main/java/org/apache/openjpa/jdbc/sql/PostgresDictionary.java
@@ -142,6 +142,7 @@ public class PostgresDictionary extends DBDictionary {
         supportsDeferredConstraints = true;
         supportsSelectStartIndex = true;
         supportsSelectEndIndex = true;
+        needNewDDLConn = false;
 
         maxTableNameLength = 63;
         maxColumnNameLength = 63;


### PR DESCRIPTION
For PostgreSQL, DDL operations do not require a new DB connection